### PR TITLE
Update anyarray_remove.sql

### DIFF
--- a/stable/anyarray_remove.sql
+++ b/stable/anyarray_remove.sql
@@ -19,7 +19,7 @@ $BODY$
                 FOR loop_offset IN ARRAY_LOWER(from_array, 1)..ARRAY_UPPER(from_array, 1) LOOP
                         -- If the element being iterated over is in "remove_array",
                         -- do not append it to "return_array".
-                        IF NOT from_array[loop_offset] = ANY(remove_array) THEN
+                        IF (from_array[loop_offset] = ANY(remove_array)) IS DISTINCT FROM TRUE THEN
                                 return_array = ARRAY_APPEND(return_array, from_array[loop_offset]);
                         END IF;
                 END LOOP;


### PR DESCRIPTION
Fix a bug where if the second (right hand side) array contains NULL, then the function incorrectly returns an empty array. E.g.,

```
SELECT '{"one","two","three"}'::text[] - '{"two",NULL}'::text[]
-- Returns: {}
```
